### PR TITLE
Bugfix for wait_pidfile

### DIFF
--- a/src/common/utils.sh
+++ b/src/common/utils.sh
@@ -45,7 +45,7 @@ wait_pidfile() {
       while [ -e /proc/$pid ]; do
         sleep 0.1
         [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
-        if [ $timeout -gt 0 ]; then
+        if [ $timeout -ge 0 ]; then
           if [ $countdown -eq 0 ]; then
             if [ "$force" = "1" ]; then
               echo -ne "\nKill timed out, using kill -9 on $pid... "


### PR DESCRIPTION
- should kill process immediately when timeout=0 and force=1

Signed-off-by: Yun Lv lvyun@huawei.com
